### PR TITLE
Run CI_pytest on 3 latest OS

### DIFF
--- a/.github/workflows/CI_pytest.yml
+++ b/.github/workflows/CI_pytest.yml
@@ -15,9 +15,10 @@ on:
 jobs:
   pytest:
 
-    runs-on: ubuntu-latest
+    runs-on: ${{ matrix.os }}
     strategy:
       matrix:
+        os: [ubuntu-latest, macos-latest, windows-latest]
         python-version: [3.8]
 
     steps:


### PR DESCRIPTION
This runs the CI_pytest routine on ``ubuntu-latest``, ``macos-latest``, and ``windows-latest``. 

It ought to help identify any platform-specific issues early on.