### PR TITLE
Fix Github issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -6,10 +6,10 @@ assignees:
 body:
   - type: checkboxes
     attributes:
-    label: Is there already an issue for this?
-    description: Look at the [open](https://github.com/MeteoSwiss/dvas/issues) and [closed](https://github.com/MeteoSwiss/dvas/issues?utf8=%E2%9C%93&q=is%3Aissue+is%3Aclosed+) issues.
-    options:
-      - label: I found no existing issue for this bug.
+      label: Is there already an issue for this?
+      description: Look at the [open](https://github.com/MeteoSwiss/dvas/issues) and [closed](https://github.com/MeteoSwiss/dvas/issues?utf8=%E2%9C%93&q=is%3Aissue+is%3Aclosed+) issues.
+      options:
+        - label: I found no existing issue for this bug.
     validations:
       required: true
   - type: textarea
@@ -23,13 +23,13 @@ body:
       required: true
   - type: textarea
     attributes:
-    label: Steps to reproduce
-    description: Steps to reproduce the bug.
-    placeholder: |
-      1. In this environment...
-      2. With this config...
-      3. Run '...'
-      4. See error...
+      label: Steps to reproduce
+      description: Steps to reproduce the bug.
+      placeholder: |
+        1. In this environment...
+        2. With this config...
+        3. Run '...'
+        4. See error...
     validations:
       required: false
   - type: textarea
@@ -41,17 +41,17 @@ body:
       render: shell
   - type: textarea
     attributes:
-    label: Environment
-    description: |
-      examples:
-        - **OS**: Ubuntu 20.04
-        - **Python**: 3.11.1
-        - **dvas**: 1.0.0
-    value: |
-        - OS:
-        - Python:
-        - dvas:
-    render: markdown
+      label: Environment
+      description: |
+        examples:
+          - **OS**: Ubuntu 20.04
+          - **Python**: 3.11.1
+          - **dvas**: 1.0.0
+      value: |
+          - OS:
+          - Python:
+          - dvas:
+      render: markdown
     validations:
       required: false
   - type: checkboxes

--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -4,12 +4,13 @@ title: "[Bug]: "
 labels: ["triage"]
 assignees:
 body:
-- type: checkboxes
-  attributes:
+  - type: checkboxes
+    attributes:
     label: Is there already an issue for this?
     description: Look at the [open](https://github.com/MeteoSwiss/dvas/issues) and [closed](https://github.com/MeteoSwiss/dvas/issues?utf8=%E2%9C%93&q=is%3Aissue+is%3Aclosed+) issues.
     options:
-    - label: I found no existing issue for this bug.
+      - label: I found no existing issue for this bug.
+    validations:
       required: true
   - type: textarea
     id: description
@@ -20,8 +21,8 @@ body:
       value: "A clear and concise description of what happened."
     validations:
       required: true
-- type: textarea
-  attributes:
+  - type: textarea
+    attributes:
     label: Steps to reproduce
     description: Steps to reproduce the bug.
     placeholder: |
@@ -29,8 +30,8 @@ body:
       2. With this config...
       3. Run '...'
       4. See error...
-  validations:
-    required: false
+    validations:
+      required: false
   - type: textarea
     id: logs
     attributes:
@@ -38,8 +39,8 @@ body:
       description: |
         Copy and paste any relevant log output. This will be automatically formatted into code, so no need for backticks.
       render: shell
-- type: textarea
-  attributes:
+  - type: textarea
+    attributes:
     label: Environment
     description: |
       examples:
@@ -51,8 +52,8 @@ body:
         - Python:
         - dvas:
     render: markdown
-  validations:
-    required: false
+    validations:
+      required: false
   - type: checkboxes
     id: terms
     attributes:

--- a/.github/ISSUE_TEMPLATE/todo.yml
+++ b/.github/ISSUE_TEMPLATE/todo.yml
@@ -4,7 +4,7 @@ title: "[New Feature]: "
 labels: ["todo"]
 assignees:
 body:
-- type: markdown
+  - type: markdown
     attributes:
       value: |
         This is to keep track of **dev-approved** changes.


### PR DESCRIPTION
**Description:**

This fixes a series of typos in the Github Issue templates introduced in #292 

**Error(s) fixed:**

**Checklists**:
- [ ] New code includes dedicated tests.
- [ ] New code has been linted.
- [ ] New code follows the project's style.
- [ ] New code is compatible with a GPL v3 license.
- [ ] CHANGELOG has been updated.
- [ ] AUTHORS has been updated.
